### PR TITLE
fix social icons

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -16,7 +16,7 @@ customCSS = ["css/custom.css", "css/icomoon.css"]
 # Social links
 [[social]]
     name = "LinkedIn"
-    icon = "fa-brands fa-2x fa-linkedin-square"
+    icon = "fa-brands fa-2x fa-linkedin"
     weight = 1
     url = "https://www.linkedin.com/in/ehlerttobias/"
     rel = "noreferrer"


### PR DESCRIPTION
- switching `linkedin-square` to `linkedin`

rel #15