### PR TITLE
chore: update metadata

### DIFF
--- a/config/_default/languages.toml
+++ b/config/_default/languages.toml
@@ -2,7 +2,7 @@
   languageName = ":us:"
   [en.params]
     description = "Tobias Lindberg's website"
-    info = "Senior Consultant | Developer | Father | Tesla enthusiast | Creator of TibiaData"
+    info = "Cloud Infrastructure Engineer | Father | Tesla enthusiast | Creator of TibiaData"
     footercontent = "This page is hosted on GitHub Pages"
     images = ["images/open-graph-image-en.png"]
 
@@ -10,7 +10,7 @@
   languageName = ":sweden:"
   [se.params]
     description = "Tobias Lindberg's hemsida"
-    info = "Seniorkonsult | Utvecklare | Far | Tesla entusiast | Skapare av TibiaData"
+    info = "Cloud Infrastructure Engineer | Far | Tesla entusiast | Skapare av TibiaData"
     footercontent = "Denna sida tillhandahålls på GitHub Pages"
     images = ["images/open-graph-image-se.png"]
 
@@ -18,6 +18,6 @@
   languageName = ":de:"
   [de.params]
     description = "Tobias Lindberg's webseite"
-    info = "Senior Consultant | Entwickler | Vater | Tesla-Enthusiast | Schöpfer von TibiaData"
+    info = "Cloud Infrastructure Engineer | Vater | Tesla-Enthusiast | Schöpfer von TibiaData"
     footercontent = "Diese Seite wird auf GitHub Pages gehostet"
     images = ["images/open-graph-image-de.png"]

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -1,5 +1,5 @@
 author = "Tobias Lindberg"
-keywords = "tobias lindberg,tobias ehlert,ehlert,consultant,senior consultant,developer"
+keywords = "tobias lindberg,tobias ehlert,ehlert,cloud infrastructure engineer"
 
 avatarurl = "images/avatar.jpg"
 # gravatar = "tobias.ehlert@gmail.com"


### PR DESCRIPTION
This pull request updates the professional title and related metadata for Tobias Lindberg across the site configuration files. The main change is the shift from "Senior Consultant / Developer" to "Cloud Infrastructure Engineer," which is reflected in both the multi-language info sections and the global keywords.

rel https://github.com/tobiasehlert/tobiaslindberg.com/pull/132